### PR TITLE
i.sentinel_2.ndvidiff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,3 +16,4 @@ per-file-ignores =
     ./i.sentinel_2.autotraining/i.sentinel_2.autotraining.py: E501,F821
     ./i.sentinel_2.parallel.index/i.sentinel_2.parallel.index.py: E501,F821
     ./i.sentinel_2.sen2cor/i.sentinel_2.sen2cor.py: E501,F821
+    ./i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.py: E501,F821

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,8 +1,11 @@
 name: Python Flake8, black and pylint code quality check
 
-on: [push]
+on: [push, pull_request]
 
 
 jobs:
   lint:
     uses: mundialis/github-workflows/.github/workflows/linting.yml@main
+    with:
+      VALIDATE_HTML: false
+

--- a/i.sentinel_2.html
+++ b/i.sentinel_2.html
@@ -27,13 +27,18 @@ downloads, imports and preprocesses multi-spectral Sentinel-2 satellite data fro
 
 <h2>DESCRIPTION</h2>
 
-The <em>i.sentinel_2</em> toolset consists of currently two modules:
+The <em>i.sentinel_2</em> toolset consists of currently four modules:
 
 <ul>
+ <li><a href="i.sentinel_2.autotraining.html">i.sentinel_2.autotraining</a>: Automatically generates training data from spectral indices and
+     a reference classification and treecover map</li>
   <li><a href="i.sentinel_2.parallel.index.html">i.sentinel_2.parallel.index</a>:
       calculates different indices in parallel</li>
   <li><a href="i.sentinel_2.sen2cor.html">i.sentinel_2.sen2cor</a>: runs atmospheric correction
       on a single Sentinel-2 L1C scene using sen2cor</li>
+  <li><a href="i.sentinel_2.ndvidiff.html">i.sentinel_2.ndvidiff</a>: Calculates NDVI difference
+      maps from Sentinel-2 data</li>
+
 </ul>
 
 <h2>REQUIREMENTS</h2>

--- a/i.sentinel_2.html
+++ b/i.sentinel_2.html
@@ -37,7 +37,7 @@ The <em>i.sentinel_2</em> toolset consists of currently four modules:
   <li><a href="i.sentinel_2.sen2cor.html">i.sentinel_2.sen2cor</a>: runs atmospheric correction
       on a single Sentinel-2 L1C scene using sen2cor</li>
   <li><a href="i.sentinel_2.ndvidiff.html">i.sentinel_2.ndvidiff</a>: Calculates NDVI difference
-      maps from Sentinel-2 data</li>
+      maps from Sentinel-2 L2A data</li>
 
 </ul>
 

--- a/i.sentinel_2.ndvidiff/Makefile
+++ b/i.sentinel_2.ndvidiff/Makefile
@@ -1,0 +1,7 @@
+MODULE_TOPDIR = ../..
+
+PGM = i.sentinel_2.ndvidiff
+
+include $(MODULE_TOPDIR)/include/Make/Script.make
+
+default: script

--- a/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.html
+++ b/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.html
@@ -37,6 +37,9 @@ The <em>nprocs</em> option can be used to run the different submodules in parall
 With the <em>min_size</em> option, small areas of detected NDVI loss may be removed
 <p>
 The <em>rgbi_basename</em> option can be used to define a basename in case the aggregated RGBI maps should be persistent in GRASS
+<p>
+A minimum NDVI value can be passed by the <em>relevant_min_ndvi</em> option. In this case, identification of significant NDVI loss areas is<br>
+delimited to pixels where the first aggregated NDVI map has a value of at least <em>relevant_min_ndvi</em>.
 
 <h2>EXAMPLE</h2>
 

--- a/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.html
+++ b/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.html
@@ -1,10 +1,10 @@
 <h2>DESCRIPTION</h2>
 
-<em>i.sentinel_2.ndvidiff</em> is a GRASS addon that calculates an NDVI difference map from Sentinel-2 data.
+<em>i.sentinel_2.ndvidiff</em> is a GRASS addon that calculates an NDVI difference map from Sentinel-2 L2A data.
 
 <p>
 The goal of the addon is to compare the NDVI status from two time intervals for an AOI given by the vector map <em>aoi</em>. For each interval, <br>
-Sentinel-2 data is imported from the local file system (using <a href="https://github.com/mundialis/t.sentinel">t.sentinel.import</a>), cloud-masked (using <a href="https://github.com/mundialis/t.sentinel">t.sentinel.mask</a>),<br>
+Sentinel-2 L2A data is imported from the local file system (using <a href="https://github.com/mundialis/t.sentinel">t.sentinel.import</a>) given with` input_dir_first` and `input_dir_second`, cloud-masked (using <a href="https://github.com/mundialis/t.sentinel">t.sentinel.mask</a>),<br>
     and temporally aggregated to receive one spectral band (using <a href="https://github.com/mundialis/t.rast.mosaic">t.rast.mosaic</a>) per time interval.
 <p>
 One NDVI map for each time interval as well as a difference map between the two are calculated. The user may define <br>

--- a/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.html
+++ b/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.html
@@ -1,0 +1,68 @@
+<h2>DESCRIPTION</h2>
+
+<em>i.sentinel_2.ndvidiff</em> is a GRASS addon that calculates an NDVI difference map from Sentinel-2 data.
+
+<p>
+The goal of the addon is to compare the NDVI status from two time intervals for an AOI given by the vector map <em>aoi</em>. For each interval, <br>
+Sentinel-2 data is imported from the local file system (using <a href="https://github.com/mundialis/t.sentinel">t.sentinel.import</a>), cloud-masked (using <a href="https://github.com/mundialis/t.sentinel">t.sentinel.mask</a>),<br>
+    and temporally aggregated to receive one spectral band (using <a href="https://github.com/mundialis/t.rast.mosaic">t.rast.mosaic</a>) per time interval.
+<p>
+One NDVI map for each time interval as well as a difference map between the two are calculated. The user may define <br>
+a threshold via the <em>ndvi_diff_threshold</em> option, which is used to extract areas of signficant NDVI loss as raster and/or vector maps. <br>
+<p>
+The outputs of the module (RGBI mosaics, NDVI maps, NDVI difference map, NDVI loss areas) can be saved as GRASS raster/vector maps or <br>
+exported using the <em>output_dir</em> option.
+
+
+<h2>NOTES</h2>
+The <em>offset</em> option can be used to take the systematic reflectance offset into account that is added to Sentinel-2 <br>
+reflectance data since Processing Baseline 4.0.0.
+<p>
+If no <em>ndvi_diff_threshold</em>  is given, a threshold is automatically calculated from the NDVI difference map using <br>
+<em>thresh = Q1 - 1.5 * (Q3 - Q1)</em>, where Q1 and Q3 are the first and third quantile of the NDVi difference map.
+<p>
+For cloud masking, the Sen2Cor cloud mask delivered with L2A data is combined with the output of <a href="https://github.com/mundialis/t.sentinel">t.sentinel.mask</a>.
+<p>
+The temporal aggregation method to be passed on to <a href="https://github.com/mundialis/t.rast.mosaic">t.rast.mosaic</a> can be defined via the <em>aggregation_method</em> option.<br>
+Best results were achieved with <em>minimum</em> aggregation which reduces negative effects due to remaining clouds.
+<p>
+The <em>cloud_shadow_buffer</em> option can be used to define a buffer radius (in raster cells) that is applied to detected <br>
+clouds and cloud shadows to compensate for inaccuracies in the cloud/shadow detection.
+<p>
+Cloud/Shadow masking is optional and is activated via the <em>-c</em> flag. If visual inspection shows that all input S-2 scenes <br>
+are cloudfree, it may be omitted.
+<p>
+The <em>nprocs</em> option can be used to run the different submodules in parallel.
+<p>
+With the <em>min_size</em> option, small areas of detected NDVI loss may be removed
+<p>
+The <em>rgbi_basename</em> option can be used to define a basename in case the aggregated RGBI maps should be persistent in GRASS
+
+<h2>EXAMPLE</h2>
+
+<h3>Create an NDVI difference map in GRASS only, save intermediate results, skip cloud/shadow detection, use an automatic threshold for the detection of significant NDVi loss</h3>
+
+<div class="code"><pre>
+i.sentinel_2.ndvidiff input_dir_first=~/S2_2020 input_dir_second=~/S2_2024 aoi=aoi_vector ndvi_loss_map_rast=ndvi_loss_result ndvi_diff_map=ndvi_diff_map_2024_2020 ndvi_map_first=ndvi_s2_2020 ndvi_map_second=ndvi_s2_2024 nprocs=4 offset=-1000 aggregation_method=minimum
+</pre></div>
+
+<h3>Export the NDVI difference map and intermediate results to a local directory, use a defined threshold, apply cloud masking and use a cloud/shadow buffer, apply a minimum size</h3>
+<div class="code"><pre>
+i.sentinel_2.ndvidiff -c input_dir_first=~/S2_2020 input_dir_second=~/S2_2024 aoi=aoi_vector offset=-1000 nprocs=4 cloud_shadow_buffer=10 aggregation_method=minimum output_dir=~/result_dir ndvi_diff_threshold=-0.25 min_size=200
+</pre></div>
+
+
+<h2>REQUIREMENTS</h2>
+- <a href="t.sentinel.html">t.sentinel</a>,
+- <a href="t.rast.mosaic.html">t.rast.mosaic</a>
+- <a href="https://github.com/mundialis/grass-gis-helpers">grass-gis-helpers Python module</a>
+
+
+<h2>SEE ALSO</h2>
+<em>
+<a href="t.sentinel.html">t.sentinel</a>,
+<a href="t.rast.mosaic.html">t.rast.mosaic</a>
+</em>
+
+<h2>AUTHORS</h2>
+Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a>

--- a/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.py
+++ b/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.py
@@ -6,7 +6,7 @@
 # AUTHOR(S):   Guido Riembauer
 
 # PURPOSE:     Calculates NDVI difference maps from Sentinel-2 data
-# COPYRIGHT:   (C) 2024 by mundialis GmbH & Co. KG and the GRASS Development
+# COPYRIGHT:   (C) 2024 by mundialis GmbH & Co. KG
 #              Team
 #
 # This program is free software; you can redistribute it and/or modify
@@ -26,7 +26,6 @@
 # % keyword: imagery
 # % keyword: sentinel
 # % keyword: ndvi
-# % keyword: VHR
 # %end
 
 # %option G_OPT_M_DIR
@@ -161,7 +160,6 @@ import atexit
 import os
 import grass.script as grass
 
-# from grass_gis_helpers import general,cleanup
 
 # initialize global variables
 rm_vec = []
@@ -269,7 +267,7 @@ def main():
 
         if clouds:
             cloud_strds = f"{strds_name}_clouds_rast"
-            shadow_strds = f"{strds_name}_shadows"
+            shadow_strds = f"{strds_name}_shadows_rast"
             rm_strds_w_rasters.append(cloud_strds)
             rm_strds_w_rasters.append(shadow_strds)
             grass.message(

--- a/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.py
+++ b/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.py
@@ -198,7 +198,9 @@ def main():
             try:
                 os.makedirs(options["output_dir"])
             except Exception as e:
-                grass.fatal(_(f"Cannot create directory {options['output_dir']}: {e}"))
+                grass.fatal(
+                    _(f"Cannot create directory {options['output_dir']}: {e}")
+                )
 
     # set region to AOI
     cur_region = f"cur_region_{os.getpid()}"
@@ -222,7 +224,11 @@ def main():
             grass.fatal(_(f"Directory {in_dir} does not exist"))
         scenes = os.listdir(in_dir)
         s2_scenes = [
-            True if scene.startswith("S2") and scene.endswith(".SAFE") else False
+            (
+                True
+                if scene.startswith("S2") and scene.endswith(".SAFE")
+                else False
+            )
             for scene in scenes
         ]
         if False in s2_scenes:
@@ -289,7 +295,9 @@ def main():
             )
 
         # prepare and run t.rast.mosaic
-        grass.message(_(f"Temporally aggregating spectral bands for time step {x}..."))
+        grass.message(
+            _(f"Temporally aggregating spectral bands for time step {x}...")
+        )
         all_strds = list(grass.parse_command("t.list").keys())
         band_strds = [
             item.split("@")[0]
@@ -335,9 +343,15 @@ def main():
                 t_rast_mosaic_kwargs["shadows"] = shadow_strds
 
                 if options["cloud_shadow_buffer"]:
-                    t_rast_mosaic_kwargs["cloudbuffer"] = options["cloud_shadow_buffer"]
-                t_rast_mosaic_kwargs["shadowbuffer"] = options["cloud_shadow_buffer"]
-            grass.run_command("t.rast.mosaic", overwrite=True, **t_rast_mosaic_kwargs)
+                    t_rast_mosaic_kwargs["cloudbuffer"] = options[
+                        "cloud_shadow_buffer"
+                    ]
+                t_rast_mosaic_kwargs["shadowbuffer"] = options[
+                    "cloud_shadow_buffer"
+                ]
+            grass.run_command(
+                "t.rast.mosaic", overwrite=True, **t_rast_mosaic_kwargs
+            )
 
         # create timestep group
         if options["rgbi_basename"]:
@@ -346,9 +360,17 @@ def main():
             timestep_group = f"rgbi_s2_timestep{x}"
             rm_groups.append(timestep_group)
         if options["output_dir"] or options["rgbi_basename"]:
-            timestep_group_rasters = [red_band, green_band, blue_band, nir_band]
+            timestep_group_rasters = [
+                red_band,
+                green_band,
+                blue_band,
+                nir_band,
+            ]
             grass.run_command(
-                "i.group", group=timestep_group, input=timestep_group_rasters, quiet=True
+                "i.group",
+                group=timestep_group,
+                input=timestep_group_rasters,
+                quiet=True,
             )
             output_groups.append(timestep_group)
 
@@ -408,7 +430,10 @@ def main():
 
     grass.message(_("Vectorizing results..."))
     grass.run_command(
-        "r.to.vect", input=ndvi_loss_map, output=ndvi_loss_map_vect_tmp, type="area"
+        "r.to.vect",
+        input=ndvi_loss_map,
+        output=ndvi_loss_map_vect_tmp,
+        type="area",
     )
 
     if options["min_size"]:

--- a/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.py
+++ b/i.sentinel_2.ndvidiff/i.sentinel_2.ndvidiff.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""
+############################################################################
+#
+# MODULE:      i.sentinel_2.ndvidiff
+# AUTHOR(S):   Guido Riembauer
+
+# PURPOSE:     Calculates NDVI difference maps from Sentinel-2 data
+# COPYRIGHT:   (C) 2024 by mundialis GmbH & Co. KG and the GRASS Development
+#              Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+#############################################################################
+"""
+# %Module
+# % description: Calculates NDVI difference maps from Sentinel-2 data.
+# % keyword: imagery
+# % keyword: sentinel
+# % keyword: ndvi
+# % keyword: VHR
+# %end
+
+# %option G_OPT_M_DIR
+# % key: input_dir_first
+# % required: yes
+# % description: Input directory that holds imagery from the first time interval
+# %end
+
+# %option G_OPT_M_DIR
+# % key: input_dir_second
+# % required: yes
+# % description: Input directory that holds imagery from the second time interval
+# %end
+
+# %option G_OPT_V_INPUT
+# % key: aoi
+# % required: yes
+# % description: Vector map that holds AOI area/s
+# %end
+
+# %option G_OPT_V_OUTPUT
+# % key: ndvi_loss_map_vect
+# % required: no
+# % description: Output vector map that contains areas of NDVI loss
+# %end
+
+# %option G_OPT_R_OUTPUT
+# % key: ndvi_loss_map_rast
+# % required: no
+# % description: Output raster map that contains areas of NDVI loss (intermediate result)
+# %end
+
+# %option G_OPT_R_OUTPUT
+# % key: ndvi_diff_map
+# % required: no
+# % description: Output raster map that contains the NDVI difference map (intermediate result)
+# %end
+
+# %option G_OPT_R_OUTPUT
+# % key: ndvi_map_first
+# % required: no
+# % description: NDVI raster map of the first time interval (intermediate result)
+# %end
+
+# %option G_OPT_R_OUTPUT
+# % key: ndvi_map_second
+# % required: no
+# % description: NDVI raster map of the second time interval (intermediate result)
+# %end
+
+# %option
+# % key: rgbi_basename
+# % type: string
+# % required: no
+# % description: Basename to save aggregated RGBI-groups
+# %end
+
+# %option
+# % key: output_dir
+# % type: string
+# % required: no
+# % multiple: no
+# % description: Output directory to write result files (RGBI/ndvi/loss rasters & vectors)
+# %end
+
+# %option
+# % key: ndvi_diff_threshold
+# % type: double
+# % required: no
+# % multiple: no
+# % description: threshold to apply to NDVI difference map. If none is given, the threshold is calculated from the NDVI diff map using thr=Q1-1.5*(Q3-Q1)
+# %end
+
+# %option
+# % key: nprocs
+# % type: integer
+# % required: no
+# % answer: 1
+# % multiple: no
+# % description: Number of parallel processes to use
+# %end
+
+# %option
+# % key: offset
+# % type: integer
+# % required: no
+# % description: Offset to add to the Sentinel bands to due to specific processing baseline (e.g. -1000)
+# %end
+
+# %option
+# % key: cloud_shadow_buffer
+# % type: integer
+# % required: no
+# % answer: 5
+# % description: Buffer in pixels to account for inacurracies in cloud/shadow masks
+# %end
+
+# %option
+# % key: min_size
+# % type: integer
+# % required: no
+# % description: Minimum size of detected ndvi loss areas (in map units)
+# %end
+
+# %option
+# % key: aggregation_method
+# % type: string
+# % required: yes
+# % options: average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
+# % answer: minimum
+# % description: temporal aggregation method used in t.rast.mosaic
+# %end
+
+# %flag
+# % key: c
+# % description: Run cloud masking (and mosaicking) using t.rast.mosaic/i.sentinel.mask
+# %end
+
+# %rules
+# % required: output_dir,ndvi_loss_map_vect,ndvi_loss_map_rast
+
+# import needed libraries
+import atexit
+import os
+import grass.script as grass
+
+# from grass_gis_helpers import general,cleanup
+
+# initialize global variables
+rm_vec = []
+rm_rast = []
+rm_reg = []
+rm_strds_w_rasters = []
+rm_groups = []
+cur_region = ""
+
+
+# cleanup function (can be extended)
+def cleanup():
+    from grass_gis_helpers import cleanup
+
+    """Cleanup function (can be extended)"""
+    grass.run_command("g.region", region=cur_region)
+    cleanup.general_cleanup(
+        rm_vectors=rm_vec,
+        rm_rasters=rm_rast,
+        rm_regions=rm_reg,
+        rm_strds_w_rasters=rm_strds_w_rasters,
+        rm_groups=rm_groups,
+        rm_mask=True,
+    )
+
+
+def main():
+    from grass_gis_helpers import general
+
+    global rm_vec, rm_rast, rm_reg, rm_strds_w_rasters, rm_groups, cur_region
+    clouds = flags["c"]
+
+    # check installed addons
+    general.check_installed_addon("t.sentinel.import")
+    general.check_installed_addon("t.sentinel.mask")
+    general.check_installed_addon("t.rast.mosaic")
+    general.check_installed_addon("t.rast.algebra")
+
+    # check if output dir exists
+    if options["output_dir"]:
+        if not os.path.isdir(options["output_dir"]):
+            try:
+                os.makedirs(options["output_dir"])
+            except Exception as e:
+                grass.fatal(_(f"Cannot create directory {options['output_dir']}: {e}"))
+
+    # set region to AOI
+    cur_region = f"cur_region_{os.getpid()}"
+    rm_reg.append(cur_region)
+    grass.run_command("g.region", save=cur_region)
+    rm_reg.append(cur_region)
+    grass.run_command("g.region", vector=options["aoi"], res=10, flags="a")
+
+    # check nprocs
+    nprocs = general.set_nprocs(options["nprocs"])
+
+    # import
+    in_dir1 = options["input_dir_first"]
+    in_dir2 = options["input_dir_second"]
+
+    ndvi_rasters = []
+    output_rasters = []
+    output_groups = []
+    for x, in_dir in enumerate([in_dir1, in_dir2]):
+        if not os.path.isdir(in_dir):
+            grass.fatal(_(f"Directory {in_dir} does not exist"))
+        scenes = os.listdir(in_dir)
+        s2_scenes = [
+            True if scene.startswith("S2") and scene.endswith(".SAFE") else False
+            for scene in scenes
+        ]
+        if False in s2_scenes:
+            if True in s2_scenes:
+                grass.fatal(_(f"Both S2 and non-S2 scenes in {in_dir}"))
+        if clouds:
+            pattern = "B(02_1|03_1|04_1|08_1|8A_2|11_2|12_2)0m"
+        else:
+            pattern = "B(02_1|03_1|04_1|08_1)0m"
+        # import to STRDS
+        grass.message(_(f"Importing imagery data from {in_dir}"))
+        strds_name = f"s2_timestep{x}"
+        rm_strds_w_rasters.append(strds_name)
+
+        import_kwargs = {
+            "pattern": pattern,
+            "input_dir": in_dir,
+            "nprocs": nprocs,
+            "strds_output": strds_name,
+        }
+        if options["offset"]:
+            import_kwargs["offset"] = options["offset"]
+        if clouds:
+            import_kwargs["flags"] = "c"
+            cloud_strds_sen2cor = f"{strds_name}_clouds_sen2cor"
+            import_kwargs["strds_clouds"] = cloud_strds_sen2cor
+            rm_strds_w_rasters.append(cloud_strds_sen2cor)
+        grass.run_command("t.sentinel.import", quiet=True, **import_kwargs)
+
+        if clouds:
+            cloud_strds = f"{strds_name}_clouds_rast"
+            shadow_strds = f"{strds_name}_shadows"
+            rm_strds_w_rasters.append(cloud_strds)
+            rm_strds_w_rasters.append(shadow_strds)
+            grass.message(
+                _(f"Identifying clouds/shadows for S-2 data from timestep {x}")
+            )
+            grass.run_command(
+                "t.sentinel.mask",
+                input=strds_name,
+                metadata="default",
+                output_clouds=cloud_strds,
+                min_size_clouds=0.05,
+                min_size_shadows=0.05,
+                output_shadows=shadow_strds,
+                nprocs=nprocs,
+            )
+
+            # combine cloud masks from t.sentinel.mask and imported ones
+            clouds_combined = f"{cloud_strds}_combined"
+            rm_strds_w_rasters.append(clouds_combined)
+            algexpression = (
+                f"{clouds_combined} = "
+                f"if(isntnull({cloud_strds}),0,"
+                f"if(isntnull({cloud_strds_sen2cor}),0,null()))"
+            )
+            grass.run_command(
+                "t.rast.algebra",
+                nprocs=nprocs,
+                basename="clouds_combined",
+                expression=algexpression,
+                flags="n",
+                overwrite=True,
+            )
+
+        # prepare and run t.rast.mosaic
+        grass.message(_(f"Temporally aggregating spectral bands for time step {x}..."))
+        all_strds = list(grass.parse_command("t.list").keys())
+        band_strds = [
+            item.split("@")[0]
+            for item in all_strds
+            if item.startswith(f"{strds_name}_B")
+        ]
+        rm_strds_w_rasters.extend(band_strds)
+        # use only r,g,b,nir
+        rgb_nir_strds = []
+        if options["rgbi_basename"] or options["output_dir"]:
+            ref_list = ["B02", "B03", "B04", "B08"]
+        else:
+            # no need to calculate the other aggregations
+            ref_list = ["B04", "B08"]
+        for item in band_strds:
+            if any(band in item for band in ref_list):
+                rgb_nir_strds.append(item)
+        for item in rgb_nir_strds:
+            out_rast = f"{item}_aggregated"
+            if not options["rgbi_basename"]:
+                # in that case it is not needed in GRASS
+                rm_rast.append(out_rast)
+            t_rast_mosaic_kwargs = {
+                "input": item,
+                "output": out_rast,
+                "method": options[
+                    "aggregation_method"
+                ],  # even if clouds are left, this should remove them (but may add shadows)
+                "granularity": "all",  # this produces a single raster instead of a strds
+                "nprocs": nprocs,
+            }
+            if "B02" in item:
+                blue_band = out_rast
+            elif "B03" in item:
+                green_band = out_rast
+            elif "B04" in item:
+                red_band = out_rast
+            elif "B08" in item:
+                nir_band = out_rast
+
+            if clouds:
+                t_rast_mosaic_kwargs["clouds"] = clouds_combined
+                t_rast_mosaic_kwargs["shadows"] = shadow_strds
+
+                if options["cloud_shadow_buffer"]:
+                    t_rast_mosaic_kwargs["cloudbuffer"] = options["cloud_shadow_buffer"]
+                t_rast_mosaic_kwargs["shadowbuffer"] = options["cloud_shadow_buffer"]
+            grass.run_command("t.rast.mosaic", overwrite=True, **t_rast_mosaic_kwargs)
+
+        # create timestep group
+        if options["rgbi_basename"]:
+            timestep_group = f"{options['rgbi_basename']}_timestep{x}"
+        else:
+            timestep_group = f"rgbi_s2_timestep{x}"
+            rm_groups.append(timestep_group)
+        if options["output_dir"] or options["rgbi_basename"]:
+            timestep_group_rasters = [red_band, green_band, blue_band, nir_band]
+            grass.run_command(
+                "i.group", group=timestep_group, input=timestep_group_rasters, quiet=True
+            )
+            output_groups.append(timestep_group)
+
+        # calculate NDVI
+        grass.message(_(f"Calculating aggregated NDVI for time step {x}..."))
+        if x == 0:
+            if options["ndvi_map_first"]:
+                ndvi_map = options["ndvi_map_first"]
+            else:
+                ndvi_map = f"{strds_name}_ndvi"
+                rm_rast.append(ndvi_map)
+        elif x == 1:
+            if options["ndvi_map_second"]:
+                ndvi_map = options["ndvi_map_second"]
+            else:
+                ndvi_map = f"{strds_name}_ndvi"
+                rm_rast.append(ndvi_map)
+        ndvi_rasters.append(ndvi_map)
+        ndvi_exp = f"{ndvi_map}=float({nir_band}-{red_band})/({nir_band} + {red_band})"
+        grass.run_command("r.mapcalc", expression=ndvi_exp, quiet=True)
+
+    grass.message(_("Calculating NDVI difference and loss maps..."))
+    if options["ndvi_diff_map"]:
+        ndvi_diff_map = options["ndvi_diff_map"]
+    else:
+        ndvi_diff_map = f"ndvi_diff_map_{os.getpid()}"
+        rm_rast.append(ndvi_diff_map)
+
+    ndvi_diff_exp = f"{ndvi_diff_map}={ndvi_rasters[1]}-{ndvi_rasters[0]}"
+    grass.run_command("r.mapcalc", expression=ndvi_diff_exp, quiet=True)
+
+    if options["ndvi_diff_threshold"]:
+        ndvi_diff_threshold = options["ndvi_diff_threshold"]
+    else:
+        qs = grass.parse_command("r.univar", flags="ge", map=ndvi_diff_map)
+        q1 = float(qs["first_quartile"])
+        q3 = float(qs["third_quartile"])
+        ndvi_diff_threshold = q1 - 1.5 * (q3 - q1)
+    grass.message(_(f"NDVI loss threshold is set to {ndvi_diff_threshold}"))
+    if options["ndvi_loss_map_rast"]:
+        ndvi_loss_map = options["ndvi_loss_map_rast"]
+    else:
+        ndvi_loss_map = f"ndvi_loss_map_{os.getpid()}"
+        rm_rast.append(ndvi_loss_map)
+
+    grass.run_command("r.mask", vector=options["aoi"])
+    loss_exp = f"{ndvi_loss_map} = if({ndvi_diff_map}<={ndvi_diff_threshold},1,null())"
+    grass.run_command("r.mapcalc", expression=loss_exp, quiet=True)
+    if options["ndvi_loss_map_vect"]:
+        ndvi_loss_map_vect = options["ndvi_loss_map_vect"]
+    else:
+        ndvi_loss_map_vect = f"{ndvi_loss_map}_vect"
+        rm_vec.append(ndvi_loss_map_vect)
+
+    ndvi_loss_map_vect_tmp = f"{ndvi_loss_map_vect}_tmp"
+    rm_vec.append(ndvi_loss_map_vect_tmp)
+
+    grass.message(_("Vectorizing results..."))
+    grass.run_command(
+        "r.to.vect", input=ndvi_loss_map, output=ndvi_loss_map_vect_tmp, type="area"
+    )
+
+    if options["min_size"]:
+        grass.run_command(
+            "v.clean",
+            input=ndvi_loss_map_vect_tmp,
+            output=ndvi_loss_map_vect,
+            tool="rmarea",
+            threshold=options["min_size"],
+        )
+    else:
+        grass.run_command(
+            "g.rename",
+            vector=f"{ndvi_loss_map_vect_tmp},{ndvi_loss_map_vect}",
+            quiet=True,
+            overwrite=True,
+        )
+
+    if options["output_dir"]:
+        out_dir = options["output_dir"]
+        grass.message(_(f"Exporting result maps to {out_dir}"))
+        output_rasters.extend(ndvi_rasters)
+        output_rasters.append(ndvi_diff_map)
+        output_rasters.extend(output_groups)
+        for rast in output_rasters:
+            outpath = os.path.join(out_dir, f"{rast}.tif")
+            grass.run_command(
+                "r.out.gdal",
+                input=rast,
+                output=outpath,
+                createopt="COMPRESS=LZW,TILED=YES",
+                overviews=5,
+                flags="cm",
+                quiet=True,
+                overwrite=True,
+            )
+        outpath_vect = os.path.join(out_dir, f"{ndvi_loss_map_vect}.gpkg")
+        grass.run_command(
+            "v.out.ogr",
+            input=ndvi_loss_map_vect,
+            output=outpath_vect,
+            quiet=True,
+            overwrite=True,
+        )
+
+
+if __name__ == "__main__":
+    options, flags = grass.parser()
+    atexit.register(cleanup)
+    main()


### PR DESCRIPTION
This PR adds an Addon `i.sentinel_2.ndvidiff` which

- loads sentinel-2 data from **two** time intervals using `t.sentinel.import`
- optionally applies cloud masking using `t.sentinel.mask`
- aggregates all bands to one band per time interval using `t.rast.mosaic`

(----> perspectively, these three first tasks could be out-sourced to an own module to further increase reusability)
- calculates the aggregated NDVI for each of the two time intervals and difference between the two time intervals
- extracts areas of significant NDVI loss via threshold
- optionally exports result data to target folder

Note:
- This new addon calls various submodules, where small changes are implemented in the following PRs. Hence, these PRs need to be merged first:
   - https://github.com/mundialis/t.sentinel/pull/23
   - https://github.com/mundialis/t.sentinel/pull/24
   - https://github.com/mundialis/grass-gis-helpers/pull/34
   - https://github.com/mundialis/t.rast.mosaic/pull/7